### PR TITLE
[개발] 메인(광고판) 페이지 - '광고 신청 페이지' 링크 추가

### DIFF
--- a/layouts/header.vue
+++ b/layouts/header.vue
@@ -16,7 +16,7 @@
           </v-btn>
         </div>
         <div class="clickArea userInfoMargin">
-          <v-btn text block href="/ownerApply1" target="_blank">
+          <v-btn text block target="_blank" :to="{ name: 'ownerApply1' }">
             <v-img v-if="dayMode" :src="userInfoDay" class="iconArea"></v-img>
             <v-img v-else :src="userInfoNight" class="iconArea"></v-img>
           </v-btn>


### PR DESCRIPTION
**[개발] 메인(광고판) 페이지 - '광고 신청 페이지' 링크 추가**

1. 메인(광고판) 페이지의 헤더에 '광고 신청 페이지' 링크를 추가합니다.
#35 에서 반영이 된 부분이 있었습니다.
href로 되어있는 부분을 nuxt-router(?)를 이용하는 것으로 수정을 해보았습니다. (차이점을 찾아보려 했으나 적절한 내용을 아직 발견하지 못했습니다. 별다른 차이는 없는 것 같습니다.)

> 참고: https://router.vuejs.org/guide/essentials/navigation.html