### PR TITLE
[개발] '인증메일 전송' 버튼 기능 구현 (Axios)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,6 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
+    "vue/comment-directive": 0
   }
 }

--- a/api/advertisement.js
+++ b/api/advertisement.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import { baseApiUrl } from './index.js';
 
-axios.defaults.withCredentials = true;
-
 export default class {
   getAdvertisementList() {
     return axios.get(`${baseApiUrl}/advertisements`);

--- a/api/verificationMail.js
+++ b/api/verificationMail.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+import { baseApiUrl } from './index.js';
+
+function requestVerificationMail(payload) {
+  return axios.post(`${baseApiUrl}/verification-mails`, payload);
+}
+
+export { requestVerificationMail };

--- a/api/verificationMail.js
+++ b/api/verificationMail.js
@@ -2,7 +2,9 @@ import axios from 'axios';
 import { baseApiUrl } from './index.js';
 
 function requestVerificationMail(payload) {
-  return axios.post(`${baseApiUrl}/verification-mails`, payload);
+  return axios.post(`${baseApiUrl}/verification-mails`, payload, {
+    timeout: 10000,
+  });
 }
 
 export { requestVerificationMail };

--- a/pages/ownerApply2.vue
+++ b/pages/ownerApply2.vue
@@ -94,7 +94,12 @@
           이메일
         </div>
         <v-row no-gutters align="center" style="margin-bottom: var(--spacing-md)">
-          <v-text-field v-model="verifiedEmail" placeholder="" outlined hide-details></v-text-field>
+          <v-text-field
+            v-model="verifiedEmail"
+            placeholder="이메일을 입력해주세요."
+            outlined
+            hide-details
+          ></v-text-field>
           <input
             class="emailBtn"
             type="button"

--- a/pages/ownerApply2.vue
+++ b/pages/ownerApply2.vue
@@ -180,11 +180,11 @@
       <div class="text-center">{{ messageOnSnackBar }}</div>
     </v-snackbar>
 
-    <v-dialog v-model="isShowingUpProgressBar" hide-overlay persistent width="300">
-      <v-card color="primary" dark>
-        <v-card-text>
+    <v-dialog v-model="isShowingUpProgressBar" width="400">
+      <v-card color="blue-grey lighten-1" dark>
+        <v-card-text class="font-weight-bold text-center pt-3">
           {{ messageOnProgressBar }}
-          <v-progress-linear indeterminate color="white" class="mb-0"></v-progress-linear>
+          <v-progress-linear indeterminate color="white" class="mt-3 mb-1"></v-progress-linear>
         </v-card-text>
       </v-card>
     </v-dialog>

--- a/pages/ownerApply2.vue
+++ b/pages/ownerApply2.vue
@@ -174,9 +174,10 @@
       :color="colorOfSnackBar"
       :timeout="3000"
       :value="true"
+      text
       top
     >
-      {{ messageOnSnackBar }}
+      <div class="text-center">{{ messageOnSnackBar }}</div>
     </v-snackbar>
 
     <v-dialog v-model="isShowingUpProgressBar" hide-overlay persistent width="300">
@@ -259,6 +260,9 @@ export default {
 </script>
 
 <style scoped>
+.text-center {
+  text-align: center !important;
+}
 .notoSansFont {
   font-family: 'Noto Sans KR', sans-serif;
 }

--- a/pages/ownerApply2.vue
+++ b/pages/ownerApply2.vue
@@ -232,10 +232,10 @@ export default {
             response.data.data.receiver === vm.verifiedEmail
           ) {
             vm.verificationCode = response.data.data.verificationCode;
-            vm.colorOfSnackBar = 'success';
 
-            vm.isShowingUpProgressBar = false;
+            vm.colorOfSnackBar = 'success';
             vm.isShowingUpSnackBar = true;
+            vm.isShowingUpProgressBar = false;
 
             vm.messageOnProgressBar = null;
             vm.messageOnSnackBar = '인증 메일 발송에 성공했습니다.';
@@ -245,10 +245,10 @@ export default {
         })
         .catch(error => {
           if (error.message) console.log(error.message);
-          vm.colorOfSnackBar = 'error';
 
-          vm.isShowingUpProgressBar = false;
+          vm.colorOfSnackBar = 'error';
           vm.isShowingUpSnackBar = true;
+          vm.isShowingUpProgressBar = false;
 
           vm.messageOnProgressBar = null;
           vm.messageOnSnackBar = '인증 메일 발송에 실패했습니다.';


### PR DESCRIPTION
[개발] '인증메일 전송' 버튼 기능 구현 (Axios)

1. '인증메일 전송' 버튼을 눌렀을 때 API 호출하도록 개발했습니다.
 - timeout 10초
 - 성공 시, "인증 메일 발송에 성공했습니다." 문구 노출됩니다.
 - 실패 시, "인증 메일 발송에 실패했습니다." 문구 노출됩니다.

2. 이메일 text field에 placeholder 추가했습니다. (디자인 시안에는 없으나 있는 것이 괜찮은 것 같아서 추가해보았습니다. 문제가 되면 다시 제거하겠습니다.)

Closes #44