### PR TITLE
[개발] v-content -> v-main

### DIFF
--- a/layouts/content.vue
+++ b/layouts/content.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-content>
+  <v-main>
     <!-- content layout -->
     <v-container fluid pa-0>
       <v-layout class="contents" row wrap>
@@ -53,7 +53,7 @@
         </div>
       </v-layout>
     </v-container>
-  </v-content>
+  </v-main>
 </template>
 
 <script>


### PR DESCRIPTION
**[개발] v-content -> v-main**

1.  콘솔에 아래 내용이 확인되어, content.vue 페이지에 있는 v-content 를 v-main으로 수정합니다.

```
Vuetify] [UPGRADE] 'v-content' is deprecated, use 'v-main' instead.

found in

---> <VMain>
       <ContentLayout>
         <VApp>
           <Layouts/default.vue> at layouts/default.vue
             <Root>
```

Closes #49