### PR TITLE
[개발] 로그인 시, 어드민 계정 -> 어드민 페이지로 리다이렉션

### DIFF
--- a/pages/owner/login.vue
+++ b/pages/owner/login.vue
@@ -55,6 +55,7 @@
 
 <script>
 import { loginApi } from '~/api/login';
+import { getUser } from '~/api/user';
 
 export default {
   layout: 'ownerDefault',
@@ -98,7 +99,18 @@ export default {
     },
     loginSuccess() {
       const vm = this;
-      vm.$router.push({ name: 'owner' });
+      const admin = 'ROLE_ADMIN';
+      getUser()
+        .then(response => {
+          if (response.data.data.role === admin) {
+            vm.$router.push({ name: 'admin-lists' });
+          } else {
+            vm.$router.push({ name: 'owner' });
+          }
+        })
+        .catch(() => {
+          vm.loginFailure();
+        });
     },
     loginFailure() {
       const vm = this;


### PR DESCRIPTION
**[개발] 로그인 시, 어드민 계정 -> 어드민 페이지로 리다이렉션**

1. 로그인 페이지에서 로그인 할 때, 어드민 계정은 어드민 페이지로 리다이렉션 되도록 개선했습니다.
- admin/lists 페이지로 리다이렉션
- admin 계정이 아닌 경우, 현재와 같이 owner 페이지(광고주의 광고 조회하기 페이지) 로 이동