### PR TITLE
[개발] 어드민 승인대기 페이지 일부 수정 (신규, 승인 상태 관련)

### DIFF
--- a/pages/admin/checklist.vue
+++ b/pages/admin/checklist.vue
@@ -161,7 +161,10 @@ export default {
   },
   watch: {
     fetchPosterRequests() {
-      this.posters = this.fetchPosterRequests.map(fetchPosterRequest => ({
+      this.posters = this.fetchPosterRequests.filter(
+        fetchPosterRequest => fetchPosterRequest.reviewStatus !== 'APPROVAL',
+      );
+      this.posters = this.posters.map(fetchPosterRequest => ({
         ...fetchPosterRequest,
         reviewStatus: this.showUpReviewStatus(fetchPosterRequest.reviewStatus),
         period: this.calculatePeriod(
@@ -292,8 +295,8 @@ export default {
       return parseInt(days / 30) + ' 개월 ' + (days % 30) + ' 일';
     },
     showUpReviewStatus(reviewStatus) {
-      if (reviewStatus === 'APPROVAL') {
-        return '승인';
+      if (reviewStatus === 'NEW') {
+        return '신규';
       } else if (reviewStatus === 'PENDING') {
         return '보류';
       } else {
@@ -301,7 +304,7 @@ export default {
       }
     },
     getColorByReviewStatus(reviewStatus) {
-      if (reviewStatus === 'APPROVAL' || reviewStatus === '승인') {
+      if (reviewStatus === 'NEW' || reviewStatus === '신규') {
         return 'blue';
       } else if (reviewStatus === 'PENDING' || reviewStatus === '보류') {
         return 'green';


### PR DESCRIPTION
**[개발] 어드민 승인대기 페이지 일부 수정 (신규, 승인 상태 관련)**

1. 어드민 승인대기 페이지 일부 수정했습니다.
- '신규' 상태 추가
- '승인' 상태 비노출 (Ex. 포스터-요청을 승인하게 되면 해당 건은 더 이상 노출되지 않음)
