### PR TITLE
[개발] 메인페이지 -> 포스터 '활성화' 상태만 노출

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -109,7 +109,12 @@ export default {
   methods: {
     init() {
       const vm = this;
-      vm.$store.dispatch('poster/FETCH_LIST');
+      const params = {
+        page: '-1',
+        isFilteredDate: true,
+        isActivated: true,
+      };
+      vm.$store.dispatch('poster/FETCH_LIST_V2', params);
     },
 
     getPostersFromColumn(targetColumn) {


### PR DESCRIPTION
**[개발] 메인페이지 -> 포스터 '활성화' 상태만 노출**

1. 메인페이지에서 포스터(광고) 의 상태가 '활성화'인 포스터만 노출되도록 수정했습니다.
- 포스터에는 '활성화', '비활성화' 상태가 존재합니다.