### PR TITLE
[개발] 광고주 광고조회 페이지 - 이미지 프리뷰 모달창 개발

### DIFF
--- a/pages/admin/checklist.vue
+++ b/pages/admin/checklist.vue
@@ -95,6 +95,7 @@
       </v-row>
     </div>
 
+    <!-- Dialog: '처리(승인/보류/미승인)' 버튼에 사용되는 dialog 입니다. -->
     <v-dialog v-model="dialog.showingUp" max-width="350">
       <v-card>
         <v-card-title class="headline">{{ dialog.title }}</v-card-title>
@@ -185,13 +186,13 @@ export default {
     checkAdminUser() {
       const vm = this;
       const admin = 'ROLE_ADMIN';
+
       return getUser()
         .then(response => {
           vm.email = response.data.data.email;
           if (response.data.data.role !== admin) {
             vm.$router.push({ name: 'owner-login' });
           }
-          console.log(response.data.data);
         })
         .catch(() => {
           vm.$router.push({ name: 'owner-login' });
@@ -300,7 +301,6 @@ export default {
     },
     showUpDetail(item) {
       // To do
-      console.log(item);
     },
     calculatePeriod(startedDate, finishedDate) {
       const sDate = new Date(startedDate);

--- a/pages/admin/checklist.vue
+++ b/pages/admin/checklist.vue
@@ -111,6 +111,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { getUser } from '~/api/user';
 
 export default {
   layout: 'admin/default',
@@ -176,9 +177,25 @@ export default {
     vm.init();
   },
   methods: {
-    init() {
+    async init() {
       const vm = this;
-      vm.read();
+      await vm.checkAdminUser();
+      await vm.read();
+    },
+    checkAdminUser() {
+      const vm = this;
+      const admin = 'ROLE_ADMIN';
+      return getUser()
+        .then(response => {
+          vm.email = response.data.data.email;
+          if (response.data.data.role !== admin) {
+            vm.$router.push({ name: 'owner-login' });
+          }
+          console.log(response.data.data);
+        })
+        .catch(() => {
+          vm.$router.push({ name: 'owner-login' });
+        });
     },
     read() {
       this.loading = true;
@@ -188,7 +205,7 @@ export default {
         userEmail: null,
         isFilteredDate: false,
       };
-      vm.$store
+      return vm.$store
         .dispatch('posterRequest/FETCH_LIST_V2', params)
         .then(() => (this.loading = false))
         .catch(() => (this.loading = false));

--- a/pages/owner/index.vue
+++ b/pages/owner/index.vue
@@ -267,6 +267,7 @@ export default {
         page: '-1',
         userEmail: this.email,
         isFilteredDate: 'false',
+        isActivated: '-1',
       };
       vm.$store.dispatch('poster/FETCH_LIST_V2', payload);
     },

--- a/pages/owner/index.vue
+++ b/pages/owner/index.vue
@@ -127,7 +127,15 @@
                 이미지
               </div>
               <span class="text-light2">
-                {{ imagePath }}
+                <span
+                  style="cursor:pointer"
+                  @click="
+                    imageDialog.showingUp = true;
+                    imageDialog.imagePath = imagePath;
+                  "
+                >
+                  {{ imagePath }}
+                </span>
               </span>
             </v-row>
             <v-row style="margin-top:3.3%; margin-left:0px">
@@ -158,6 +166,20 @@
         </v-col>
       </v-row>
     </div>
+
+    <!-- Dialog: '이미지(프리뷰)' 버튼에 사용되는 dialog 입니다. -->
+    <v-dialog v-model="imageDialog.showingUp" width="400">
+      <v-card>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" text @click="imageDialog.showingUp = false">
+            X
+          </v-btn>
+        </v-card-actions>
+
+        <v-img :src="imageDialog.imagePath" />
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -174,6 +196,10 @@ export default {
       stringOfPosterType1: '1x1 (300 x 250)',
       stringOfPosterType2: '2x1 (300 x 516)',
       stringOfPosterType3: '3x1 (300 x 782)',
+      imageDialog: {
+        imagePath: null,
+        showingUp: false,
+      },
     };
   },
   computed: {


### PR DESCRIPTION
[개발] 광고주 광고조회 페이지 - 이미지 프리뷰 모달창 개발

1. 이전에 광고조회 페이지에서 사용될 이미지 프리뷰 모달창 개발해 둔것 일단 반영해놓겠습니다. (변경 예정)
2. admin/checklists 페이지에서, 로그인한 계정이 admin 계정이 아니라면 로그인 페이지로 리다이렉션
3. 광고주의 '광고조회' 페이지에서 '활성화' 상태의 광고만 노출되는 오류 수정 (활성화/비활성화 모두 노출)


Closes #69