### PR TITLE
[리팩토링] 메인페이지 포스터 이미지 크기 설정

### DIFF
--- a/components/PosterBox.vue
+++ b/components/PosterBox.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Poster -->
-  <div class="poster ma-1" :style="{ 'z-index': zIndex }" @click="isClicked = !isClicked">
+  <div class="poster ma-2" :style="{ 'z-index': zIndex }" @click="isClicked = !isClicked">
     <!-- Poster 이미지 -->
     <img
       class="poster-image"
@@ -10,7 +10,7 @@
       :class="[posterBox.posterType, { 'poster-image-animation': isClicked }]"
       :style="{
         width: posterBox.posterWidth + 'px !important',
-        height: posterBox.posterHeight + 'px !important',
+        height: '100%',
       }"
     />
 
@@ -21,25 +21,25 @@
       :class="{ 'poster-detail-animation': isClicked }"
       :style="{
         width: posterBox.posterWidth + 'px !important',
-        height: posterBox.posterHeight + 'px !important',
+        height: '100%',
       }"
     >
       <v-card-text style="height:100%">
         <div
           class="bottom-content poster-detail-title"
-          style="height:30%"
+          style="height:20%"
           :style="{ color: color }"
         >
           {{ posterBox.title }}
         </div>
         <div
           class="center-content poster-detail-description"
-          style="height:30%"
+          style="height:70%"
           :style="{ color: color }"
         >
           {{ posterBox.description }}
         </div>
-        <div class="bottom-content poster-detail-link" style="height:40%">
+        <div class="bottom-content poster-detail-link" style="height:10%">
           <v-btn
             target="_blank"
             :href="posterBox.siteUrl"
@@ -152,7 +152,6 @@ export default {
 <style scoped>
 img {
   max-width: 100%;
-  height: auto !important;
 }
 
 .example-image {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,32 +2,32 @@
   <v-container fluid pa-0>
     <v-row class="contents" no-gutters>
       <!-- col1 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersFirstColumn" :key="poster.id" :poster="poster" />
       </v-col>
 
       <!-- col2 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersSecondColumn" :key="poster.id" :poster="poster" />
       </v-col>
 
       <!-- col3 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersThirdColumn" :key="poster.id" :poster="poster" />
       </v-col>
 
       <!-- col4 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersFourthColumn" :key="poster.id" :poster="poster" />
       </v-col>
 
       <!-- col5 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersFifthColumn" :key="poster.id" :poster="poster" />
       </v-col>
 
       <!-- col6 -->
-      <v-col xs="4" md="4" lg="2">
+      <v-col cols="4" xs="4" md="4" lg="2">
         <poster-box v-for="poster in postersSixthColumn" :key="poster.id" :poster="poster" />
       </v-col>
     </v-row>


### PR DESCRIPTION
**[리팩토링] 메인페이지 포스터 이미지 크기 설정**

1. 해상도를 줄일수록 포스터의 크기가 세로로 길어지는 것을 보완하였습니다.
2. 광고 페이지의 상세 내용을 더 길게 작성할 수 있도록 포스터의 상세 내용부분을 더 늘렸습니다.
3. 해상도가 600px 이하로 줄어들었을 때의 레이아웃을 추가하였습니다.


Closes #122 