### PR TITLE
[개발] 사이트맵 생성

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -113,5 +113,16 @@ export default {
    */
   sitemap: {
     hostname: 'https://gg-pigs.com',
+    exclude: [
+      '/apply/**',
+      '/admin/**',
+      '/owner/**',
+      '/owner',
+      '/ownerApply1',
+      '/ownerApply2',
+      '/adminPageStatus',
+      '/adminPageApproval',
+      '/inspire',
+    ],
   },
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -50,6 +50,8 @@ export default {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
+    // Doc: https://sitemap.nuxtjs.org
+    '@nuxtjs/sitemap',
   ],
   /*
    ** Axios module configuration
@@ -105,5 +107,11 @@ export default {
         });
       });
     },
+  },
+  /*
+   ** Generate sitemap
+   */
+  sitemap: {
+    hostname: 'https://gg-pigs.com',
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.3.6",
+    "@nuxtjs/sitemap": "^2.4.0",
     "nuxt": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**[개발] 사이트맵 생성 (<- [개발] 개인 포스터 페이지 사이트맵 생성)**

1. `@nuxtjs/sitemap` 사이트맵을 자동으로 생성해주는 모듈을 적용했습니다.
 - 개인 페이지 뿐만 아니라, static routes(`pages/` 밑에 생성한 파일 기반으로 생성된 url) 도 사이트맵에 자동으로 적용됩니다.
 - 사이트맵에 적용되지 않아야 하는 페이지(현재 노출되지 않는 `/owner/~`, `/apply/**`, 혹은 `admin/**`)들은 적용되지 않도록 처리했습니다. (exclude 속성 이용)

> /dist/에 sitemap.xml 이 생긴 모습
![image](https://user-images.githubusercontent.com/35790290/106611555-76b02380-65ab-11eb-8153-d013f713a734.png)


> http://localhost:3000/sitemap.xml 확인했을 때
![image](https://user-images.githubusercontent.com/35790290/106609530-01435380-65a9-11eb-8f31-caaac25a1a3b.png)


<br>

> Reference
> 1. https://www.npmjs.com/package/@nuxtjs/sitemap
> 2. https://sitemap.nuxtjs.org/


Closes #125 