### PR TITLE
[리팩토링] 메인 페이지 포스터 자세히 보기 버튼 수정

### DIFF
--- a/components/PosterBox.vue
+++ b/components/PosterBox.vue
@@ -41,6 +41,7 @@
         </div>
         <div class="bottom-content poster-detail-link" style="height:10%">
           <v-btn
+            v-if="isClicked"
             target="_blank"
             :href="posterBox.siteUrl"
             block


### PR DESCRIPTION
**[리팩토링] 메인 페이지 포스터 자세히 보기 버튼 수정**

1. 포스터를 클릭시 자세히 보기 버튼이 활성화되도록 적용하였습니다.

Closes #130 