### PR TITLE
[리팩토링] 메인 페이지와 푸터 사이의 간격 수정

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -108,27 +108,27 @@
 .Ml5        {   margin-left: 5%;      }
 .Ml5-5      {   margin-left: 5.5%;    }
 
-.mt32       {   margin-top: 32px;     }
-.mt64       {   margin-top: 64px;     }
-.mt96       {   margin-top: 96px;     }
-.mt128      {   margin-top: 128px;    }
+.mt32       {   margin-top: 32px !important;     }
+.mt64       {   margin-top: 64px !important;     }
+.mt96       {   margin-top: 96px !important;     }
+.mt128      {   margin-top: 128px !important;    }
 
-.mb16       {   margin-bottom: 16px;  }
-.mb32       {   margin-bottom: 32px;  }
-.mb64       {   margin-bottom: 64px;  }
-.mb96       {   margin-bottom: 96px;  }
-.mb128      {   margin-bottom: 128px; }
+.mb16       {   margin-bottom: 16px !important;  }
+.mb32       {   margin-bottom: 32px !important;  }
+.mb64       {   margin-bottom: 64px !important;  }
+.mb96       {   margin-bottom: 96px !important;  }
+.mb128      {   margin-bottom: 128px !important; }
 
-.mr16       {   margin-right: 16px;   }
-.mr32       {   margin-right: 32px;   }
-.mr64       {   margin-right: 64px;   }
-.mr96       {   margin-right: 96px;   }
-.mr128      {   margin-right: 128px;  }
+.mr16       {   margin-right: 16px !important;   }
+.mr32       {   margin-right: 32px !important;   }
+.mr64       {   margin-right: 64px !important;   }
+.mr96       {   margin-right: 96px !important;   }
+.mr128      {   margin-right: 128px !important;  }
 
-.ml32       {   margin-left: 32px;    }
-.ml64       {   margin-left: 64px;    }
-.ml96       {   margin-left: 96px;    }
-.ml128      {   margin-left: 128px;   }
+.ml32       {   margin-left: 32px !important;    }
+.ml64       {   margin-left: 64px !important;    }
+.ml96       {   margin-left: 96px !important;    }
+.ml128      {   margin-left: 128px !important;   }
 
 
 /* Font Size */

--- a/layouts/main/footer.vue
+++ b/layouts/main/footer.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid pa-0 class="noto-sans-font">
-    <v-row>
+    <v-row no-gutters>
       <v-divider :class="[dayMode ? 'border-light3' : 'border-dark2']" />
     </v-row>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,7 +33,7 @@
     </v-row>
 
     <!-- Pagination -->
-    <v-row class="mb64" align="center" justify="center">
+    <v-row no-gutters class="mb64" align="center" justify="center">
       <div class="clickArea" style="padding:6px 15px; text-align: center;" @click="prevPage()">
         <img :src="[dayMode ? 'icon/prePageDay.svg' : 'icon/prePageNight.svg']" class="pageIcon" />
       </div>


### PR DESCRIPTION
**[리팩토링] 메인 페이지와 푸터 사이의 간격 수정**

1. `<v-row>`에 `no-gutters` 속성을 주어 메인 페이지와 푸터가 겹쳐지는 것을 수정하였습니다.
2. `style.css` 의 마진 값이 적용될 수 있도록 `!important`속성을 추가하였습니다.

Closes #134 