### PR TITLE
[Bug] Modify the tab button click area of the owner header layout

### DIFF
--- a/components/OwnerHeader.vue
+++ b/components/OwnerHeader.vue
@@ -97,9 +97,8 @@ header {
   height: 29px;
 }
 
-.tab {
+.tab-link {
   padding: 1rem;
-  cursor: pointer;
   font-size: 1.125rem;
 }
 


### PR DESCRIPTION
**[Bug] Modify the tab button click area of the owner header layout**

1. onwer header layout의 tab 버튼 클릭영역을 수정하였습니다.

closes #150 